### PR TITLE
Text of rake command incorrect

### DIFF
--- a/ruby-on-rails/polymorphic-resource-owner.md
+++ b/ruby-on-rails/polymorphic-resource-owner.md
@@ -24,7 +24,7 @@ end
 Generate migration to add polymorphic columns to tables:
 
 ```bash
-$ bundle exec rails g doorkeeper:enable_polymorphic_resource_owner
+$ bundle exec rails g doorkeeper:polymorphic_resource_owner
 ```
 
 If you previously set foreign key for `:resource_owner_id` column - you need to drop it as now it


### PR DESCRIPTION
the command that exists is `bundle exec rails g doorkeeper:polymorphic_resource_owner`, it is the generated migration that is called `enable_polymorphic_resource_owner`, not the rake task