### PR TITLE
Add note to PKCE doc for those who overrode the view

### DIFF
--- a/ruby-on-rails/pkce-flow.md
+++ b/ruby-on-rails/pkce-flow.md
@@ -53,3 +53,4 @@ bundle exec rails generate doorkeeper:pkce
 
 This step is optional and you will be able to add this later if necessary.
 
+If you overrode the `doorkeeper/authorizations/new.html.erb` view, make sure that you have the `code_challenge` and `code_challenge_method` hidden form fields.


### PR DESCRIPTION
I had issues enabling PKCE today and found this [StackOverflow post](https://stackoverflow.com/questions/59379154/enable-pkce-with-doorkeeper) that saved me. I felt like it was worth adding a note to the documentation.