### PR TITLE
Warn people about the latency cost of using BCrypt

### DIFF
--- a/security/token-and-application-secrets.md
+++ b/security/token-and-application-secrets.md
@@ -49,7 +49,7 @@ In this request, you need to ensure the user noted the secret since you will no 
 **Using BCrypt gem for application secrets**
 
 Since application secrets are to be treated as password, Doorkeeper also allows you to store secrets as BCrypt hashes.
-To enable it, simply add it to your Gemfile: 
+To enable it, simply add it to your Gemfile **This will add ~200ms latency to endpoints that verify client secret**: 
 
 {% code-tabs %}
 {% code-tabs-item title="Gemfile" %}


### PR DESCRIPTION
Storing client secrets using BCrypt is a bad idea if you mint a lot of tokens and need to call endpoints that verify client secret as it adds a latency of ~200ms

![image](https://user-images.githubusercontent.com/43916/170414720-64494bbc-92a1-4488-a53c-64a75d75fa8a.png)
